### PR TITLE
docs: rename spec dirs to role-based names

### DIFF
--- a/docs/spec/containers/README.md
+++ b/docs/spec/containers/README.md
@@ -9,9 +9,9 @@ containers/
 ├── compose.yaml          # 全サービスのオーケストレーション (1ファイル)
 ├── .env                  # 認証情報 (git 管理外)
 ├── .env.example          # 認証情報テンプレート (git 管理対象)
-├── dagster/              # Dagster (webserver, daemon, code location)
-├── postgres/             # PostgreSQL
-└── rustfs/               # RustFS (S3 互換 Object Storage)
+├── orchestrator/         # Dagster (webserver, daemon, code location)
+├── relational_database/  # PostgreSQL
+└── object_storage/       # RustFS (S3 互換 Object Storage)
 ```
 
 ## compose.yaml の方針

--- a/docs/spec/containers/object_storage/README.md
+++ b/docs/spec/containers/object_storage/README.md
@@ -1,4 +1,4 @@
-# containers/rustfs/
+# containers/object_storage/
 
 S3 互換 Object Storage。論文 PDF などのバイナリデータを格納する。
 

--- a/docs/spec/containers/orchestrator/README.md
+++ b/docs/spec/containers/orchestrator/README.md
@@ -1,11 +1,11 @@
-# containers/dagster/
+# containers/orchestrator/
 
 Dagster のカスタム Docker イメージとユーザーコード。
 
 ## ディレクトリ構成
 
 ```
-dagster/
+orchestrator/
 ├── Dockerfile
 ├── dagster.yaml          # インスタンス設定 (ストレージバックエンド等)
 ├── workspace.yaml        # code location 定義

--- a/docs/spec/containers/relational_database/README.md
+++ b/docs/spec/containers/relational_database/README.md
@@ -1,11 +1,11 @@
-# containers/postgres/
+# containers/relational_database/
 
 PostgreSQL 17 のサービス定義と初期化スクリプト。
 
 ## ディレクトリ構成
 
 ```
-postgres/
+relational_database/
 └── init/
     └── 001_create_schemas.sql
 ```
@@ -33,7 +33,7 @@ postgres/
 
 ## 初期化
 
-`containers/postgres/init/` に SQL ファイルを配置し、Docker の `docker-entrypoint-initdb.d` マウントで自動実行する。
+`containers/relational_database/init/` に SQL ファイルを配置し、Docker の `docker-entrypoint-initdb.d` マウントで自動実行する。
 
 ```sql
 -- 001_create_schemas.sql


### PR DESCRIPTION
## Summary

`docs/spec/containers/` 配下の3つのサブディレクトリを技術名から役割名にリネームし、内容のパス参照を更新した。Issue #1 で導入する実装側ディレクトリ命名 (orchestrator / relational_database / object_storage) と仕様側を揃える。

## なぜリネームするのか

これまで spec ディレクトリは `dagster/` `postgres/` `rustfs/` のように **採用した技術名 (What)** で切られていた。これは初見でも意味が伝わるが、3つの問題がある:

1. **依存性逆転と矛盾する**: ホームラボの設計指針として「上位層は具体実装ではなく役割に依存する」を採用しているのに、ディレクトリ名が具体実装に縛られていた
2. **将来の差し替えに弱い**: 例えば Dagster を Prefect / Airflow に差し替えたい場合、ディレクトリリネーム + 全 cross-reference 修正が発生する
3. **読者に技術スタック前提を強要する**: 「Dagster を知らない人」にとって `dagster/` は意味不明だが、`orchestrator/` ならパイプラインの司令塔だと推測できる

そこで Issue #1 で実装側を役割ベース命名に決め、その方針を spec 側にも先行適用する PR を切った。

## 命名の意思決定

最終形:

| Before (What) | After (Role) | 役割 |
|---|---|---|
| `dagster/` | `orchestrator/` | パイプラインのオーケストレーション |
| `postgres/` | `relational_database/` | リレーショナルDB |
| `rustfs/` | `object_storage/` | S3 互換オブジェクトストレージ |

検討の過程で何度か命名を見直しているので、それぞれ採用理由を残す。

### `database/` ではなく `relational_database/`

最初の案は `database/` だった。しかし「object storage も広義の database」という指摘があり、汎用すぎることが分かった。`relational_database/` と `object_storage/` を「データの保存方式」軸で並べると、将来 KVS や TSDB を足したときも `key_value_store/` `time_series_database/` のように対称的に並ぶ。

### `rdb/` ではなく `relational_database/`

略語 `rdb/` も候補だったが、もう一方が `object_storage/` というフルワードなので不揃いになる。略語は記述量を減らすが、ディレクトリ名は読みやすさを優先しフルワードで統一した。

### `object_store/` ではなく `object_storage/`

途中まで `object_store/` で進めていたが、AWS / GCP / Azure 公式ドキュメントが揃って "Object Storage" を使っているので、業界標準語彙に合わせた。

### ハイフンではなくアンダースコア

単語区切りはアンダースコアで統一。後発の Issue で他のディレクトリを足すときの命名揺れを防ぐ。

## 変更内容

- ディレクトリ3つを `git mv` でリネーム（履歴保持）
  - `docs/spec/containers/dagster/` → `orchestrator/`
  - `docs/spec/containers/postgres/` → `relational_database/`
  - `docs/spec/containers/rustfs/` → `object_storage/`
- 各 README 内のパス参照を新しいディレクトリ名に更新
  - 親 `containers/README.md` のディレクトリツリー
  - 子 README の見出し (`# containers/<name>/`) と冒頭のディレクトリツリー
  - `relational_database/README.md` 内の `containers/postgres/init/` 参照

## 意図的に変更しなかったもの

- **Docker イメージ名**: `object_storage/README.md` 16行目の `rustfs/rustfs` は Docker Hub のイメージ識別子であり、ディレクトリ名ではないので変更しない
- **散文中の技術名**: 「Dagster のカスタム Docker イメージ」「PostgreSQL 17」「RustFS」のような文脈における固有名詞は、何の技術を採用しているかを伝える情報なので残す
- **Compose service 名**: `dagster-webserver` `dagster-daemon` `dagster-code-location` `postgres` `rustfs` という compose の service key は実装名のまま。これは compose ネットワーク上の識別子であり、技術名そのものを使うのが慣習

## 関連

- Closes part of: #1 (Issue #1 では実装側を同じ命名で作成する)
- Issue #1 本文も今回の `object_storage` 採用に合わせて更新済み

## レビュー観点

- [x] ディレクトリ名 3つが妥当か（`orchestrator` / `relational_database` / `object_storage`）
- [x] 略語 vs フルワードのトレードオフ判断（`rdb` を退けた理由）に同意できるか
- [x] 散文中の技術名を残した範囲が適切か（変えるべき箇所が漏れていないか）
- [x] 親 README のディレクトリツリーと実際のディレクトリ構成が一致しているか

## Test plan

- [x] `find docs/spec/containers -type d` で3つのリネーム後ディレクトリのみ存在することを確認
- [x] `grep -rn "dagster/\|postgres/\|rustfs/" docs/` で残存参照を確認（`rustfs/rustfs` の Docker イメージ名のみ残るはず）
- [x] GitHub 上で各 README をレンダリングし、見出しとディレクトリツリーが新名称になっているか目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)