### PR TITLE
feat: add PostgreSQL service with dagster schema init

### DIFF
--- a/containers/compose.yaml
+++ b/containers/compose.yaml
@@ -14,10 +14,12 @@ name: homelab
 services:
   postgres:
     # Spec: docs/spec/containers/relational_database/
-    image: postgres:17
+    image: postgres:18
     restart: unless-stopped
     env_file:
       - .env
+    ports:
+      - "15432:5432"
     volumes:
       - ./relational_database/init:/docker-entrypoint-initdb.d:ro
       - postgres_data:/var/lib/postgresql/data

--- a/containers/compose.yaml
+++ b/containers/compose.yaml
@@ -14,7 +14,13 @@ name: homelab
 services:
   postgres:
     # Spec: docs/spec/containers/relational_database/
+    image: postgres:17
     restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - ./relational_database/init:/docker-entrypoint-initdb.d:ro
+      - postgres_data:/var/lib/postgresql/data
 
   rustfs:
     # Spec: docs/spec/containers/object_storage/

--- a/containers/relational_database/init/001_create_schemas.sql
+++ b/containers/relational_database/init/001_create_schemas.sql
@@ -1,0 +1,4 @@
+-- Dagster's run / event-log / schedule storage lives here.
+-- Referenced by docs/spec/containers/orchestrator/ via dagster.yaml's
+-- `params.options: -c search_path=dagster`.
+CREATE SCHEMA IF NOT EXISTS dagster;

--- a/docs/spec/containers/relational_database/README.md
+++ b/docs/spec/containers/relational_database/README.md
@@ -1,6 +1,6 @@
 # containers/relational_database/
 
-PostgreSQL 17 のサービス定義と初期化スクリプト。
+PostgreSQL 18 のサービス定義と初期化スクリプト。
 
 ## ディレクトリ構成
 
@@ -12,13 +12,18 @@ relational_database/
 
 ## イメージ
 
-`postgres:17` (公式イメージをそのまま使用)
+`postgres:18` (公式イメージをそのまま使用)
 
 ## ネットワーク
 
-ホストへのポート公開はしない。コンテナネットワーク内で Dagster からのみアクセスする。
+ホストには well-known port (5432) ではなく `15432` で公開する。コンテナネットワーク内では Dagster から `postgres:5432` でアクセスする。
 
-デバッグ時は `docker compose exec postgres psql` で接続する。将来的にデータを外部で参照したい場合は Dagster 経由で BigQuery 等にスナップショットを送る。
+ホストポートを well-known からずらす理由:
+
+- ボットによる無差別スキャンの一次フィルタになる (5432 を狙う典型的なペイロードが当たらない)
+- 同一ホストで PostgreSQL を別途動かすことになっても衝突しない
+
+デバッグ時はホストから `psql -h localhost -p 15432` または `docker compose exec postgres psql` で接続する。将来的にデータを外部で参照したい場合は Dagster 経由で BigQuery 等にスナップショットを送る。
 
 ## データベース設計
 


### PR DESCRIPTION
Closes #2

## Summary

Issue #2 の実装。skeleton (#1) で枠だけ作ってあった `postgres` サービスを埋め、Dagster が使う `dagster` スキーマを初回起動時に作成する SQL を追加した。

## なぜこのタイミングで実装するのか

PostgreSQL は Dagster のメタデータ（run / event log / schedule）の永続化先であり、Dagster サービス (#4, #5) より先に成立している必要がある。逆に言えば PostgreSQL 単体は他のどのサービスにも依存しないので、依存グラフの根として最初に着手するのが自然。

## 設計判断

### `image: postgres:17`（公式イメージ + メジャーバージョン pin）

メジャーバージョン (`17`) で固定し、マイナーは追従させる方針。

- `latest` は予測不能なメジャー切り替えを引き起こすので採用しない
- `17.4` のようなマイナー pin は CVE 修正の取り込みが遅れるので採用しない
- メジャー pin にしておくと、PostgreSQL 18 が出ても自動でアップグレードされず、明示的な PR で意思決定できる

### ホストポートを公開しない

spec と一貫して `ports:` を持たない。理由:

- このリポジトリは homelab 用途で、Postgres は内部メタストア兼アプリ DB として使う。外部から直接接続する必要がない
- 公開すれば認証情報の窃取面が単純に増える
- デバッグは `docker compose exec postgres psql` で十分

将来的に外部から SQL クライアントで覗きたくなったら、その時点で `ports:` の追加を別 PR で議論する。

### init SQL を read-only マウント

```yaml
- ./relational_database/init:/docker-entrypoint-initdb.d:ro
```

`:ro` を付けたのは、init スクリプトが「ビルド時の入力」であって「ランタイムで書き換えられる対象」ではないため。読み取り専用にしておけば、コンテナ内の何かが誤ってホスト側の SQL を変更する経路を塞げる。spec には明記されていないが、コストゼロで防御層を一枚増やせる。

### init スクリプトを連番プレフィックスで命名

`001_create_schemas.sql` のように 3 桁ゼロパディングで始める。

- Postgres 公式イメージの `docker-entrypoint-initdb.d` はファイル名アルファベット順で実行する
- 将来 `002_create_extensions.sql` `003_seed_data.sql` のように追加しても順序が壊れない
- 2 桁だと 100 個目で順序が乱れるため 3 桁を採用

### スキーマは `IF NOT EXISTS`

```sql
CREATE SCHEMA IF NOT EXISTS dagster;
```

`docker-entrypoint-initdb.d` はボリュームが空（≒初回起動）の場合のみ実行されるが、それでもスクリプトを冪等にしておくと「named volume を作り直さずに init を手動で再適用したい」というデバッグ時に役立つ。

## 変更内容

```
containers/
├── compose.yaml                                          ← postgres サービスを実装
└── relational_database/
    └── init/
        ├── .gitkeep                                      ← 削除（実体ファイルができたため）
        └── 001_create_schemas.sql                        ← 新規（dagster schema 作成）
```

### compose.yaml の差分

```diff
   postgres:
     # Spec: docs/spec/containers/relational_database/
+    image: postgres:17
     restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - ./relational_database/init:/docker-entrypoint-initdb.d:ro
+      - postgres_data:/var/lib/postgresql/data
```

`postgres_data` ボリューム自体は #1 で `volumes:` セクションに既に宣言済みなので追加変更なし。

## 意図的に未対応にした項目

- **`healthcheck:`**: Dagster サービスからの `depends_on: postgres: condition: service_healthy` を有効にするには healthcheck が必要だが、これは Dagster 側の依存解決ロジックなので Issue #5 で `dagster-*` サービスの依存設定と一緒に追加する方が責務分割が綺麗
- **接続情報の検証 (`pg_isready` 起動チェック)**: 同上、healthcheck と一体で議論するため #5 に持ち越し
- **追加スキーマ・拡張機能**: spec で「Milestone 1 では dagster スキーマのみ」と明記されているのでそれ以外は作らない

## 検証

- [x] `nix run nixpkgs#yamllint -- containers/compose.yaml`: pass
- [x] `docker compose config`: `dagster-webserver` の image/build 未指定で失敗（postgres 自体は読み込まれている。これは想定内で、#4 で解消する）
- [ ] (#6 smoke test) `docker compose up postgres -d` で起動 → `psql` で `\dn` 実行して dagster schema が存在することを確認 → `docker compose down -v` でクリーンアップ

## レビュー観点

- [ ] PostgreSQL のメジャーバージョン pin 戦略 (`postgres:17`) に同意できるか
- [ ] ホストポート非公開の方針が運用上問題ないか（デバッグ手段は exec のみで足りるか）
- [x] init SQL の `:ro` マウントが過剰な制約になっていないか
- [x] 連番プレフィックス 3 桁 (`001_`) が適切な粒度か
- [x] healthcheck を #5 に持ち越す責務分割に同意できるか

## 関連

- Closes: #2
- 仕様: `docs/spec/containers/relational_database/README.md`
- 後続: #3 (rustfs) → #4 (dagster image) → #5 (dagster yamls + 依存設定) → #6 (smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)