### PR TITLE
Add RustFS service to compose.yaml

### DIFF
--- a/containers/compose.yaml
+++ b/containers/compose.yaml
@@ -26,7 +26,16 @@ services:
 
   rustfs:
     # Spec: docs/spec/containers/object_storage/
+    image: rustfs/rustfs:latest
     restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "19000:9000"
+      - "19001:9001"
+    volumes:
+      - rustfs_data:/data
+    command: /data
 
   dagster-webserver:
     # Spec: docs/spec/containers/orchestrator/


### PR DESCRIPTION
Closes #3.

## 背景

[直前の PR #11](https://github.com/shunsock/homelab/pull/11) で RustFS spec を公式ドキュメントに合わせて訂正した。本 PR はその訂正後の spec に従い、`compose.yaml` の `rustfs` skeleton を実体化する。

## 変更点

`containers/compose.yaml` の `rustfs` サービスに以下を追加:

| フィールド | 値 | 出典 |
|---|---|---|
| `image` | `rustfs/rustfs:latest` | spec |
| `env_file` | `.env` | リポジトリ規約 (postgres と同じ) |
| `ports` | `19000:9000`, `19001:9001` | spec |
| `volumes` | `rustfs_data:/data` | spec (既存 named volume を使用) |
| `command` | `/data` | spec (MinIO と異なり data dir 引数のみ) |

新規ファイルなし。`volumes:` の `rustfs_data` 宣言は既に PR #9 で入っているため触らない。

## 動作確認

`docker compose up rustfs` は dagster-* skeleton が `image`/`build` を持たないため Compose v5 の project validation で落ちる (Issue #4/#5 の範囲)。代わりに `docker run` で同等の構成を起動して挙動を検証した。

確認した点:

- ✅ API (`http://localhost:19000`) が応答 (無認証 GET で 403、これは S3 の正常応答)
- ✅ Console (`http://localhost:19001`) が応答 (403、SPA の bare GET 応答として期待どおり)
- ✅ named volume `rustfs_data` への書き込み成功 — コンテナは uid `10001` で動くが permission エラーは発生せず、spec で挙げた permission-fixer helper は**現時点では不要**と判明
- ✅ `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` で起動可能
- ✅ ログに `Initializing data directories: /data` → `Starting: /usr/bin/rustfs /data` と出力され、`/data` 引数が正しく解釈される

## トレードオフ・判断

- **permission-fixer を入れない**: spec には「権限問題が起きたら helper を追加」と書いた。今回の検証では起きなかったので **YAGNI で省略**。将来 image が更新されて再発したら spec に従って追加する。
- **dagster-* skeleton の修正は別 PR**: Compose v5 の strict validation で skeleton が invalid だと判明したが、これは Issue #4/#5 のスコープなので本 PR では触らない。`docker compose up rustfs` を直接叩けないのは一時的な制約。

## レビューで見てほしい点

- spec (PR #11 反映後) と compose の対応が崩れていないか
- 検証手順が production の振る舞いと乖離していないか (特に named volume の権限まわり)

🤖 Generated with [Claude Code](https://claude.com/claude-code)