### PR TITLE
Rename Dagster user-code dir from code/ to app/ (and Linux user to app-user)

### DIFF
--- a/docs/spec/containers/orchestrator/README.md
+++ b/docs/spec/containers/orchestrator/README.md
@@ -11,14 +11,18 @@ orchestrator/
 ├── workspace.yaml           # code location 定義
 ├── pyproject.toml           # Python 依存定義
 ├── uv.lock                  # ロックファイル
-└── homelab_orchestrator/    # ユーザーコード (asset, job, resource)
+└── app/                     # ユーザーコード (asset, job, resource)
 ```
 
 ### ユーザーコードのディレクトリ名
 
-`homelab_orchestrator/` という名前を採用する。短い `code/` のような名前は **避ける**。
+`app/` という名前を採用する。短い `code/` のような名前は **避ける**。
 
-理由: Python の `pdb` などの標準モジュールは内部で `import code` (stdlib の対話インタプリタ) を行う。`/app` を `WORKDIR` に持つコンテナでユーザーコードを `code/` という名前にすると、import 解決で `/app/code/` が stdlib の `code` を上書きしてしまい、Dagster の import チェーンが循環参照で破綻する (実装時に検証済み)。プロジェクト名と揃えた `homelab_orchestrator/` ならこの衝突を回避でき、`-m homelab_orchestrator` で起動コマンドにもそのまま利用できる。
+理由: Python の `pdb` などの標準モジュールは内部で `import code` (stdlib の対話インタプリタ) を行う。`/app` を `WORKDIR` に持つコンテナでユーザーコードを `code/` という名前にすると、import 解決で `/app/code/` が stdlib の `code` を上書きしてしまい、Dagster の import チェーンが循環参照で破綻する (実装時に検証済み)。`app/` は stdlib および主要ライブラリと衝突せず、`-m app` で起動コマンドにもそのまま利用できる。
+
+### Linux ユーザー名との衝突回避
+
+ディレクトリ名 `app/` は WORKDIR `/app` と並ぶため、コンテナ内の Linux ユーザー名まで `app` にすると 1 語が 3 つの異なる対象 (WORKDIR / Linux ユーザー / Python モジュール) を指すことになりレビュー時の認知負荷が高い。Linux ユーザー名は **`app-user`** とし、Python モジュール名 `app` と分離する。
 
 ## Docker イメージ
 
@@ -29,7 +33,7 @@ orchestrator/
 ### ビルド方針
 
 - マルチステージビルドを採用する。ビルドステージで依存をインストールし、ランタイムステージにコピーする。
-- 非 root ユーザー (app) で実行する。
+- 非 root ユーザー (`app-user`) で実行する。
 - 依存管理は `pyproject.toml` + `uv.lock` で宣言的に行う。
 
 ### サービス構成
@@ -40,7 +44,7 @@ orchestrator/
 |---------|---------|-------|
 | dagster-webserver | `dagster-webserver -h 0.0.0.0 -p 13000` | 13000 (ホスト公開) |
 | dagster-daemon | `dagster-daemon run` | なし |
-| dagster-code-location | `dagster code-server start -h 0.0.0.0 -p 4000 -m homelab_orchestrator` | 4000 (コンテナ内のみ) |
+| dagster-code-location | `dagster code-server start -h 0.0.0.0 -p 4000 -m app` | 4000 (コンテナ内のみ) |
 
 ## dagster.yaml
 
@@ -73,7 +77,7 @@ load_from:
       location_name: "homelab"
 ```
 
-## ユーザーコード (homelab_orchestrator/)
+## ユーザーコード (app/)
 
 Dagster の asset, job, resource 定義を配置する。Milestone 1 ではスケルトンのみ作成し、Milestone 2 以降で arXiv 収集パイプラインや Claude Code バッチなどを追加する。
 

--- a/docs/spec/containers/orchestrator/README.md
+++ b/docs/spec/containers/orchestrator/README.md
@@ -7,12 +7,18 @@ Dagster のカスタム Docker イメージとユーザーコード。
 ```
 orchestrator/
 ├── Dockerfile
-├── dagster.yaml          # インスタンス設定 (ストレージバックエンド等)
-├── workspace.yaml        # code location 定義
-├── pyproject.toml        # Python 依存定義
-├── uv.lock               # ロックファイル
-└── code/                 # ユーザーコード (asset, job, resource)
+├── dagster.yaml             # インスタンス設定 (ストレージバックエンド等)
+├── workspace.yaml           # code location 定義
+├── pyproject.toml           # Python 依存定義
+├── uv.lock                  # ロックファイル
+└── homelab_orchestrator/    # ユーザーコード (asset, job, resource)
 ```
+
+### ユーザーコードのディレクトリ名
+
+`homelab_orchestrator/` という名前を採用する。短い `code/` のような名前は **避ける**。
+
+理由: Python の `pdb` などの標準モジュールは内部で `import code` (stdlib の対話インタプリタ) を行う。`/app` を `WORKDIR` に持つコンテナでユーザーコードを `code/` という名前にすると、import 解決で `/app/code/` が stdlib の `code` を上書きしてしまい、Dagster の import チェーンが循環参照で破綻する (実装時に検証済み)。プロジェクト名と揃えた `homelab_orchestrator/` ならこの衝突を回避でき、`-m homelab_orchestrator` で起動コマンドにもそのまま利用できる。
 
 ## Docker イメージ
 
@@ -34,7 +40,7 @@ orchestrator/
 |---------|---------|-------|
 | dagster-webserver | `dagster-webserver -h 0.0.0.0 -p 13000` | 13000 (ホスト公開) |
 | dagster-daemon | `dagster-daemon run` | なし |
-| dagster-code-location | `dagster code-server start -h 0.0.0.0 -p 4000` | 4000 (コンテナ内のみ) |
+| dagster-code-location | `dagster code-server start -h 0.0.0.0 -p 4000 -m homelab_orchestrator` | 4000 (コンテナ内のみ) |
 
 ## dagster.yaml
 
@@ -67,7 +73,7 @@ load_from:
       location_name: "homelab"
 ```
 
-## ユーザーコード (code/)
+## ユーザーコード (homelab_orchestrator/)
 
 Dagster の asset, job, resource 定義を配置する。Milestone 1 ではスケルトンのみ作成し、Milestone 2 以降で arXiv 収集パイプラインや Claude Code バッチなどを追加する。
 


### PR DESCRIPTION
## 背景

Issue #4 (Dagster カスタムイメージ作成) を実装中、ビルドしたコンテナで \`import dagster\` が **循環参照エラー** で落ちることが判明した:

\`\`\`
File "/usr/local/lib/python3.12/pdb.py", line 77, in <module>
    import code
File "/app/code/__init__.py", line 1, in <module>
    from dagster import Definitions
ImportError: cannot import name 'Definitions' from partially initialized module 'dagster'
   (most likely due to a circular import)
\`\`\`

### 根本原因

- spec のディレクトリ名 \`code/\` が **Python stdlib の \`code\` モジュール** (対話インタプリタ) と衝突する
- WORKDIR が \`/app\` の状態で \`/app/code/\` が存在すると、import 解決順で \`/app/code/\` が stdlib \`code\` を上書きする
- Dagster は内部的に \`pdb\` を import し、\`pdb\` は \`code.interact()\` のために \`import code\` する
- 結果、\`code/__init__.py\` が dagster の初期化途中に再帰的に dagster を参照しようとして循環参照になる

要するに **WORKDIR \`/app\` + ユーザーコード名 \`code/\` の組合せは成立しない**。命名で詰みパターンを踏んでいた。

## 変更点

\`docs/spec/containers/orchestrator/README.md\`:

- ユーザーコードのディレクトリ名を \`code/\` → **\`app/\`** に変更
  - stdlib および主要ライブラリと衝突しない
  - \`-m app\` で起動コマンドにそのまま使える
- Linux ユーザー名を \`app\` → **\`app-user\`** に変更
  - WORKDIR \`/app\` + Python モジュール \`app/\` と並ぶ場面で、Linux ユーザー名まで \`app\` だと 1 語が 3 つの異なる対象を指すことになり認知負荷が高いため分離
- \`dagster code-server\` コマンドに \`-m app\` を追加（コードロード方法を明示）

## 採用した案と却下案

| 候補 | 判定 | 理由 |
|---|---|---|
| **\`app/\` + Linux \`app-user\`** | ✅ 採用 | 短く typing コストが低い。Linux ユーザーを別名にすれば認知負荷を許容範囲に抑えられる |
| \`homelab_orchestrator/\` + Linux \`app\` | ❌ | 衝突は無いが命名が冗長。当初提案だが見送り |
| \`app/\` + Linux \`app\` | ❌ | WORKDIR / Linux user / Python module の 3 重衝突で読み手の認知負荷が高い |
| \`pipelines/\` | ❌ | 中身を端的に示すが、Milestone 2 以降で pipeline 以外の asset/resource も増える |
| \`defs/\` | ❌ | Dagster 用語だが短すぎて context が薄い |

## 実装 PR との関係

- 本 PR は spec 訂正のみ
- マージ後に Issue #4 の実装 PR を続ける（Dockerfile, pyproject.toml, uv.lock, \`app/__init__.py\`、Linux ユーザーは \`app-user\`）

## Test plan

- [x] 衝突ケースを実装ブランチで再現済（\`docker run ... python -c "import dagster"\` でエラー）
- [ ] 実装 PR で新名でビルドし、import が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)