### PR TITLE
Fix postgres mount for Postgres 18 layout (/var/lib/postgresql)

### DIFF
--- a/containers/compose.yaml
+++ b/containers/compose.yaml
@@ -22,7 +22,7 @@ services:
       - "15432:5432"
     volumes:
       - ./relational_database/init:/docker-entrypoint-initdb.d:ro
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
 
   rustfs:
     # Spec: docs/spec/containers/object_storage/

--- a/docs/spec/containers/relational_database/README.md
+++ b/docs/spec/containers/relational_database/README.md
@@ -47,4 +47,6 @@ CREATE SCHEMA IF NOT EXISTS dagster;
 
 ## 永続化
 
-named volume `postgres_data` を `/var/lib/postgresql/data` にマウントする。
+named volume `postgres_data` を `/var/lib/postgresql` にマウントする。
+
+PostgreSQL 18 以降の公式イメージは、データをメジャーバージョン別のサブディレクトリ (例: `/var/lib/postgresql/18/docker/`) に格納する仕様に変わった。これは将来 `pg_upgrade --link` でマイナー/メジャーアップグレードする際にマウント境界をまたがず済むようにするための設計変更で、従来の `/var/lib/postgresql/data` 直下マウントは公式に拒否される。マウントは親ディレクトリ `/var/lib/postgresql` 側に当てる必要がある。


### PR DESCRIPTION
## 背景

Issue #5 (Dagster サービス配線) を進めて初めて \`docker compose up\` が compose validation を通り、すべてのサービスを起動しようとした結果、**postgres コンテナが起動失敗** することが判明した:

\`\`\`
Error: in 18+, these Docker images are configured to store database data in a
   format which is compatible with "pg_ctlcluster" ...
   Counter to that, there appears to be PostgreSQL data in:
     /var/lib/postgresql/data (unused mount/volume)
   The suggested container configuration for 18+ is to place a single mount
   at /var/lib/postgresql which will then place PostgreSQL data in a
   subdirectory ...
\`\`\`

## 根本原因

[PR #10](https://github.com/shunsock/homelab/pull/10) で image を \`postgres:18\` に bump したが、マウント先は postgres 16 以前の慣習である \`/var/lib/postgresql/data\` のままだった。Postgres 18+ は **メジャーバージョン別のサブディレクトリ** (例: \`/var/lib/postgresql/18/docker/\`) にデータを置く設計に変わっており、従来の \`/var/lib/postgresql/data\` 直下マウントを公式イメージが**拒否**する。これは将来 \`pg_upgrade --link\` でメジャーアップグレードする際にマウント境界をまたがず済むようにするための変更 ([upstream PR #1259](https://github.com/docker-library/postgres/pull/1259))。

PR #10 のマージ時点ではこのバグは表面化しなかった。理由は当時 \`compose.yaml\` に dagster-* skeleton (image/build なし) が残っていて compose validation で全体が落ちており、postgres を含む \`docker compose up\` が一度も成功していなかったため。

## 変更点

- \`containers/compose.yaml\`: \`postgres_data:/var/lib/postgresql/data\` → \`postgres_data:/var/lib/postgresql\`
- \`docs/spec/containers/relational_database/README.md\`: 同上のマウント先と、なぜ親ディレクトリへのマウントなのかの理由を追記 (将来 \`/data\` に戻す "修正" を防ぐため)

## 動作確認

\`\`\`
$ docker run -d --rm -v test_pg18:/var/lib/postgresql postgres:18 ...
$ docker logs ...
LOG:  starting PostgreSQL 18.3 ...
LOG:  database system is ready to accept connections
$ docker run --rm -v test_pg18:/v alpine ls /v
18
\`\`\`

無事起動し、ボリューム直下に \`18/\` サブディレクトリが作られることまで確認。

## Issue #5 との関係

本 fix がマージされたら Issue #5 のブランチ (\`feat/wire-dagster-services\`) を rebase して、Dagster 配線 + postgres + rustfs 全部入りで end-to-end の \`docker compose up\` を検証する。

## Test plan

- [x] \`docker run\` で postgres 18 が新マウントパスで起動することを確認
- [ ] マージ後、Issue #5 の e2e テストで実利用パターン (compose 経由) を検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)