### PR TITLE
Wire Dagster services into compose with PostgreSQL backend

### DIFF
--- a/containers/compose.yaml
+++ b/containers/compose.yaml
@@ -1,16 +1,5 @@
 name: homelab
 
-# Service skeletons. Each service's concrete configuration (image, ports,
-# env_file, volumes, depends_on, etc.) is added in the follow-up issues
-# listed below. The structure here exists so that follow-up PRs can fill
-# in details without bikeshedding layout.
-#
-#   postgres                : Issue #2 (relational database service)
-#   rustfs                  : Issue #3 (object storage service)
-#   dagster-webserver       : Issues #4, #5 (image build + workspace)
-#   dagster-daemon          : Issues #4, #5
-#   dagster-code-location   : Issues #4, #5
-
 services:
   postgres:
     # Spec: docs/spec/containers/relational_database/
@@ -37,17 +26,48 @@ services:
       - rustfs_data:/data
     command: /data
 
+  dagster-code-location:
+    # Spec: docs/spec/containers/orchestrator/
+    # Hosts the user code as a gRPC server. The webserver and daemon load it
+    # via workspace.yaml. No DAGSTER_HOME / dagster.yaml needed here — only
+    # the webserver/daemon talk to the storage backend.
+    build: ./orchestrator
+    restart: unless-stopped
+    command: dagster code-server start -h 0.0.0.0 -p 4000 -m app
+
   dagster-webserver:
     # Spec: docs/spec/containers/orchestrator/
+    build: ./orchestrator
     restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DAGSTER_HOME: /app
+    command: dagster-webserver -h 0.0.0.0 -p 13000 -w workspace.yaml
+    ports:
+      - "13000:13000"
+    volumes:
+      - ./orchestrator/dagster.yaml:/app/dagster.yaml:ro
+      - ./orchestrator/workspace.yaml:/app/workspace.yaml:ro
+    depends_on:
+      - postgres
+      - dagster-code-location
 
   dagster-daemon:
     # Spec: docs/spec/containers/orchestrator/
+    build: ./orchestrator
     restart: unless-stopped
-
-  dagster-code-location:
-    # Spec: docs/spec/containers/orchestrator/
-    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DAGSTER_HOME: /app
+    command: dagster-daemon run -w workspace.yaml
+    volumes:
+      - ./orchestrator/dagster.yaml:/app/dagster.yaml:ro
+      - ./orchestrator/workspace.yaml:/app/workspace.yaml:ro
+    depends_on:
+      - postgres
+      - dagster-code-location
 
 volumes:
   postgres_data:

--- a/containers/orchestrator/Dockerfile
+++ b/containers/orchestrator/Dockerfile
@@ -24,7 +24,10 @@ FROM python:3.12-slim-trixie AS runtime
 RUN groupadd --system --gid 1000 app-user \
  && useradd --system --uid 1000 --gid app-user --create-home app-user
 
+# /app is created by WORKDIR as root-owned by default. Chown it to app-user
+# so dagster (running as DAGSTER_HOME=/app) can write its telemetry/log dirs.
 WORKDIR /app
+RUN chown app-user:app-user /app
 
 COPY --from=builder --chown=app-user:app-user /app/.venv /app/.venv
 COPY --chown=app-user:app-user app ./app

--- a/containers/orchestrator/dagster.yaml
+++ b/containers/orchestrator/dagster.yaml
@@ -1,0 +1,13 @@
+storage:
+  postgres:
+    postgres_db:
+      hostname: postgres
+      username:
+        env: POSTGRES_USER
+      password:
+        env: POSTGRES_PASSWORD
+      db_name:
+        env: POSTGRES_DB
+      port: 5432
+      params:
+        options: "-c search_path=dagster"

--- a/containers/orchestrator/workspace.yaml
+++ b/containers/orchestrator/workspace.yaml
@@ -1,0 +1,5 @@
+load_from:
+  - grpc_server:
+      host: dagster-code-location
+      port: 4000
+      location_name: "homelab"


### PR DESCRIPTION
Closes #5. **Completes Milestone 1: データ基盤の構築** 🎉

## 背景

[PR #14](https://github.com/shunsock/homelab/pull/14) で Dagster カスタムイメージを作成し、[PR #15](https://github.com/shunsock/homelab/pull/15) で postgres 18 のマウント問題を解消した。本 PR で **dagster.yaml + workspace.yaml + compose の 3 サービス配線** を行い、Milestone 1 のスタックを end-to-end で起動可能にする。

## 変更点

### 新規ファイル

\`containers/orchestrator/\`:

| ファイル | 役割 |
|---|---|
| \`dagster.yaml\` | インスタンス設定。run / event log / schedule storage を PostgreSQL の \`dagster\` schema に向ける |
| \`workspace.yaml\` | webserver/daemon が読む code location 定義。gRPC で \`dagster-code-location:4000\` に接続 |

### \`containers/compose.yaml\`

- dagster-* skeleton 3 つを実体化:
  - \`dagster-code-location\`: \`build: ./orchestrator\`、\`command: dagster code-server start -h 0.0.0.0 -p 4000 -m app\`。ストレージに触らないため DAGSTER_HOME / dagster.yaml は不要
  - \`dagster-webserver\`: \`-w workspace.yaml\` で workspace を読み、\`13000\` でホスト公開。\`DAGSTER_HOME=/app\`、dagster.yaml と workspace.yaml を read-only bind mount
  - \`dagster-daemon\`: 同じ image / 設定で \`dagster-daemon run -w workspace.yaml\`
- 3 サービスとも \`depends_on: [postgres, dagster-code-location]\`
- 冒頭の skeleton ヘッダーコメントを削除（指していた Issue が全て実装済みのため）

### \`containers/orchestrator/Dockerfile\`

- \`WORKDIR /app\` の直後に \`chown app-user:app-user /app\` を追加
- 理由: PR #14 では \`COPY --chown\` で \`/app/.venv\` と \`/app/app\` の所有権は app-user にしていたが、\`/app\` ディレクトリ自体は WORKDIR が root 所有で作成するため放置されていた。Dagster は起動時に \`DAGSTER_HOME/.telemetry/\` を mkdir しようとするので、\`/app\` が書き込めないと webserver も daemon も即クラッシュする。Issue #5 の e2e テストで初めて表面化した PR #14 由来の latent bug

## 動作確認 (end-to-end)

\`docker compose up -d --build\` で全 5 コンテナを起動し、以下を確認:

\`\`\`
$ docker compose ps
NAME                              STATUS
homelab-dagster-code-location-1   Up
homelab-dagster-daemon-1          Up
homelab-dagster-webserver-1       Up
homelab-postgres-1                Up
homelab-rustfs-1                  Up

$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:13000/
200

$ curl -s -X POST http://localhost:13000/graphql \\
    -H 'Content-Type: application/json' \\
    -d '{"query":"{ version }"}'
{"data":{"version":"1.13.3"}}

$ curl -s -X POST http://localhost:13000/graphql \\
    -H 'Content-Type: application/json' \\
    -d '{"query":"{ workspaceOrError { ... on Workspace { locationEntries { name loadStatus locationOrLoadError { __typename } } } } }"}'
{"data":{"workspaceOrError":{"locationEntries":[
  {"name":"homelab","loadStatus":"LOADED",
   "locationOrLoadError":{"__typename":"RepositoryLocation"}}
]}}}

$ docker compose exec -T postgres psql -U homelab -d homelab -c "\\dt dagster.*"
 dagster | alembic_version                | table | homelab
 dagster | event_logs                     | table | homelab
 dagster | runs                           | table | homelab
 dagster | daemon_heartbeats              | table | homelab
 ... (22 tables in total)
\`\`\`

確認できた性質:
- ✅ webserver UI が 13000 で応答
- ✅ Dagster バージョン 1.13.3 が稼働
- ✅ code location \`homelab\` が **LOADED** で gRPC handshake 成功
- ✅ PostgreSQL の \`dagster\` schema に 22 テーブルが作成される (event_logs, runs, daemon_heartbeats など) → dagster.yaml の storage backend 設定が効いている

## 設計判断

- **dagster.yaml は bind mount**: image にコピーせず compose の bind mount で配ることで、運用中の設定変更時に再 build を不要にした
- **code-location には DAGSTER_HOME を渡さない**: gRPC でユーザーコードを serve するだけで、storage には触らないため最小権限。webserver/daemon だけが storage と通信する
- **DAGSTER_HOME=/app**: 専用 dir を別途作らず、既存の WORKDIR を流用。Milestone 1 の規模ではこれで十分。テレメトリ ID やローカルログは ephemeral になるが、永続化が必要な run/event log はすべて PostgreSQL 側に書かれる

## Milestone 1 完了

これで **Milestone 1: データ基盤の構築** が完了します:

- [x] Issue #2: PostgreSQL service ([#10](https://github.com/shunsock/homelab/pull/10))
- [x] Issue #3: RustFS service ([#11](https://github.com/shunsock/homelab/pull/11), [#12](https://github.com/shunsock/homelab/pull/12))
- [x] Issue #4: Dagster custom image ([#13](https://github.com/shunsock/homelab/pull/13), [#14](https://github.com/shunsock/homelab/pull/14))
- [x] Issue #5: Dagster wiring (本 PR)
- [x] postgres 18 mount fix ([#15](https://github.com/shunsock/homelab/pull/15))

次は Milestone 2 (arXiv 論文収集パイプライン) へ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)