### PR TITLE
Add Taskfile with DDD-flavored service-layer commands

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,7 +1,7 @@
 version: '3'
 
 # 各境界コンテキストにライフサイクル操作 (launch / shutdown / restart /
-# status) を割り当て、`homelab` を集約ルートとして全体操作を束ねる。
+# status) を割り当て、`containers` を集約ルートとして全体操作を束ねる。
 # 名前空間は DDD のサービス層メソッドに対応する。
 
 vars:
@@ -14,33 +14,33 @@ tasks:
       - task --list
     silent: true
 
-  homelab:launch:
-    desc: homelab 全体を起動する
+  containers:launch:
+    desc: 全コンテナを起動する
     deps:
       - relational_database:launch
       - object_storage:launch
       - orchestrator:launch
 
-  homelab:shutdown:
-    desc: homelab 全体を停止する
+  containers:shutdown:
+    desc: 全コンテナを停止する
     deps:
       - orchestrator:shutdown
       - object_storage:shutdown
       - relational_database:shutdown
 
-  homelab:restart:
-    desc: homelab 全体を再起動する
+  containers:restart:
+    desc: 全コンテナを再起動する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} restart
 
-  homelab:status:
-    desc: homelab 全体の稼働状況を確認する
+  containers:status:
+    desc: 全コンテナの稼働状況を確認する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} ps
 
   relational_database:launch:
     desc: リレーショナルデータベースを起動する
-    # homelab:launch と orchestrator:launch の双方から依存される
+    # containers:launch と orchestrator:launch の双方から依存される
     # ため、単一タスク実行内での重複起動を抑止する。
     run: once
     cmds:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,14 +1,8 @@
 version: '3'
 
-# Application service layer for the homelab.
-#
-# Bounded contexts map to Compose services:
-#   - relational_database  -> postgres
-#   - object_storage       -> rustfs
-#   - orchestrator         -> dagster-code-location / dagster-webserver / dagster-daemon
-#
-# The `homelab` namespace is the aggregate root that composes the
-# per-context services into whole-system lifecycle operations.
+# 各境界コンテキストにライフサイクル操作 (launch / shutdown / restart /
+# status) を割り当て、`homelab` を集約ルートとして全体操作を束ねる。
+# 名前空間は DDD のサービス層メソッドに対応する。
 
 vars:
   COMPOSE_FILE: containers/compose.yaml
@@ -20,9 +14,6 @@ tasks:
       - task --list
     silent: true
 
-  # ------------------------------------------------------------------
-  # Aggregate root: homelab
-  # ------------------------------------------------------------------
   homelab:launch:
     desc: homelab 全体を起動する
     deps:
@@ -47,14 +38,10 @@ tasks:
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} ps
 
-  # ------------------------------------------------------------------
-  # Bounded context: relational_database (PostgreSQL)
-  # ------------------------------------------------------------------
   relational_database:launch:
     desc: リレーショナルデータベースを起動する
-    # Multiple aggregates depend on this (homelab:launch and
-    # orchestrator:launch). `run: once` keeps it from being executed
-    # twice within a single task invocation.
+    # homelab:launch と orchestrator:launch の双方から依存される
+    # ため、単一タスク実行内での重複起動を抑止する。
     run: once
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} up -d postgres
@@ -74,9 +61,6 @@ tasks:
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} ps postgres
 
-  # ------------------------------------------------------------------
-  # Bounded context: object_storage (RustFS)
-  # ------------------------------------------------------------------
   object_storage:launch:
     desc: オブジェクトストレージを起動する
     cmds:
@@ -97,14 +81,11 @@ tasks:
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} ps rustfs
 
-  # ------------------------------------------------------------------
-  # Bounded context: orchestrator (Dagster)
-  # ------------------------------------------------------------------
-  # Dagster requires the relational database to be running, so launch
-  # depends on relational_database:launch. Compose's own depends_on
-  # handles internal ordering between code-location/webserver/daemon.
   orchestrator:launch:
     desc: オーケストレーターを起動する
+    # Dagster の永続化先である Postgres への依存はコンテキスト境界を
+    # またぐためタスク側で明示する。Compose の depends_on は同一
+    # コンテキスト内 (code-location/webserver/daemon) の順序のみ扱う。
     deps:
       - relational_database:launch
     cmds:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,126 @@
+version: '3'
+
+# Application service layer for the homelab.
+#
+# Bounded contexts map to Compose services:
+#   - relational_database  -> postgres
+#   - object_storage       -> rustfs
+#   - orchestrator         -> dagster-code-location / dagster-webserver / dagster-daemon
+#
+# The `homelab` namespace is the aggregate root that composes the
+# per-context services into whole-system lifecycle operations.
+
+vars:
+  COMPOSE_FILE: containers/compose.yaml
+
+tasks:
+  default:
+    desc: List available tasks
+    cmds:
+      - task --list
+    silent: true
+
+  # ------------------------------------------------------------------
+  # Aggregate root: homelab
+  # ------------------------------------------------------------------
+  homelab:launch:
+    desc: Launch every bounded context
+    deps:
+      - relational_database:launch
+      - object_storage:launch
+      - orchestrator:launch
+
+  homelab:shutdown:
+    desc: Shut down every bounded context
+    deps:
+      - orchestrator:shutdown
+      - object_storage:shutdown
+      - relational_database:shutdown
+
+  homelab:restart:
+    desc: Restart every bounded context
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} restart
+
+  homelab:status:
+    desc: Report the status of every bounded context
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} ps
+
+  # ------------------------------------------------------------------
+  # Bounded context: relational_database (PostgreSQL)
+  # ------------------------------------------------------------------
+  relational_database:launch:
+    desc: Launch the relational database
+    # Multiple aggregates depend on this (homelab:launch and
+    # orchestrator:launch). `run: once` keeps it from being executed
+    # twice within a single task invocation.
+    run: once
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} up -d postgres
+
+  relational_database:shutdown:
+    desc: Shut down the relational database
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} stop postgres
+
+  relational_database:restart:
+    desc: Restart the relational database
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} restart postgres
+
+  relational_database:status:
+    desc: Report the status of the relational database
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} ps postgres
+
+  # ------------------------------------------------------------------
+  # Bounded context: object_storage (RustFS)
+  # ------------------------------------------------------------------
+  object_storage:launch:
+    desc: Launch the object storage
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} up -d rustfs
+
+  object_storage:shutdown:
+    desc: Shut down the object storage
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} stop rustfs
+
+  object_storage:restart:
+    desc: Restart the object storage
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} restart rustfs
+
+  object_storage:status:
+    desc: Report the status of the object storage
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} ps rustfs
+
+  # ------------------------------------------------------------------
+  # Bounded context: orchestrator (Dagster)
+  # ------------------------------------------------------------------
+  # Dagster requires the relational database to be running, so launch
+  # depends on relational_database:launch. Compose's own depends_on
+  # handles internal ordering between code-location/webserver/daemon.
+  orchestrator:launch:
+    desc: Launch the orchestrator
+    deps:
+      - relational_database:launch
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} up -d dagster-code-location dagster-webserver dagster-daemon
+
+  orchestrator:shutdown:
+    desc: Shut down the orchestrator
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} stop dagster-webserver dagster-daemon dagster-code-location
+
+  orchestrator:restart:
+    desc: Restart the orchestrator
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} restart dagster-code-location dagster-webserver dagster-daemon
+
+  orchestrator:status:
+    desc: Report the status of the orchestrator
+    cmds:
+      - docker compose -f {{.COMPOSE_FILE}} ps dagster-code-location dagster-webserver dagster-daemon

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -15,7 +15,7 @@ vars:
 
 tasks:
   default:
-    desc: List available tasks
+    desc: 利用可能なタスクを一覧表示する
     cmds:
       - task --list
     silent: true
@@ -24,26 +24,26 @@ tasks:
   # Aggregate root: homelab
   # ------------------------------------------------------------------
   homelab:launch:
-    desc: Launch every bounded context
+    desc: homelab 全体を起動する
     deps:
       - relational_database:launch
       - object_storage:launch
       - orchestrator:launch
 
   homelab:shutdown:
-    desc: Shut down every bounded context
+    desc: homelab 全体を停止する
     deps:
       - orchestrator:shutdown
       - object_storage:shutdown
       - relational_database:shutdown
 
   homelab:restart:
-    desc: Restart every bounded context
+    desc: homelab 全体を再起動する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} restart
 
   homelab:status:
-    desc: Report the status of every bounded context
+    desc: homelab 全体の稼働状況を確認する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} ps
 
@@ -51,7 +51,7 @@ tasks:
   # Bounded context: relational_database (PostgreSQL)
   # ------------------------------------------------------------------
   relational_database:launch:
-    desc: Launch the relational database
+    desc: リレーショナルデータベースを起動する
     # Multiple aggregates depend on this (homelab:launch and
     # orchestrator:launch). `run: once` keeps it from being executed
     # twice within a single task invocation.
@@ -60,17 +60,17 @@ tasks:
       - docker compose -f {{.COMPOSE_FILE}} up -d postgres
 
   relational_database:shutdown:
-    desc: Shut down the relational database
+    desc: リレーショナルデータベースを停止する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} stop postgres
 
   relational_database:restart:
-    desc: Restart the relational database
+    desc: リレーショナルデータベースを再起動する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} restart postgres
 
   relational_database:status:
-    desc: Report the status of the relational database
+    desc: リレーショナルデータベースの稼働状況を確認する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} ps postgres
 
@@ -78,22 +78,22 @@ tasks:
   # Bounded context: object_storage (RustFS)
   # ------------------------------------------------------------------
   object_storage:launch:
-    desc: Launch the object storage
+    desc: オブジェクトストレージを起動する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} up -d rustfs
 
   object_storage:shutdown:
-    desc: Shut down the object storage
+    desc: オブジェクトストレージを停止する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} stop rustfs
 
   object_storage:restart:
-    desc: Restart the object storage
+    desc: オブジェクトストレージを再起動する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} restart rustfs
 
   object_storage:status:
-    desc: Report the status of the object storage
+    desc: オブジェクトストレージの稼働状況を確認する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} ps rustfs
 
@@ -104,23 +104,23 @@ tasks:
   # depends on relational_database:launch. Compose's own depends_on
   # handles internal ordering between code-location/webserver/daemon.
   orchestrator:launch:
-    desc: Launch the orchestrator
+    desc: オーケストレーターを起動する
     deps:
       - relational_database:launch
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} up -d dagster-code-location dagster-webserver dagster-daemon
 
   orchestrator:shutdown:
-    desc: Shut down the orchestrator
+    desc: オーケストレーターを停止する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} stop dagster-webserver dagster-daemon dagster-code-location
 
   orchestrator:restart:
-    desc: Restart the orchestrator
+    desc: オーケストレーターを再起動する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} restart dagster-code-location dagster-webserver dagster-daemon
 
   orchestrator:status:
-    desc: Report the status of the orchestrator
+    desc: オーケストレーターの稼働状況を確認する
     cmds:
       - docker compose -f {{.COMPOSE_FILE}} ps dagster-code-location dagster-webserver dagster-daemon

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777826146,
+        "narHash": "sha256-wQ/iN5Zp5VIa3ebBibijPnLyKhor+xEbDy4d0goa9Zs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "73c703c22422b8951895a960959dbbaca7296492",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
           default = pkgs.mkShell {
             packages = with pkgs; [
               git
+              go-task
             ];
           };
         }


### PR DESCRIPTION
## Summary

- リポジトリ root に `Taskfile.yaml` を追加し、`containers/compose.yaml` 配下のサービスのライフサイクル操作 (`launch` / `shutdown` / `restart` / `status`) を提供する。
- 名前空間は DDD の境界づけられたコンテキストに対応：`relational_database` (postgres) / `object_storage` (rustfs) / `orchestrator` (dagster-*)。
- `containers:*` を集約ルートとし、`deps:` 経由で各コンテキストのタスクを束ねる。
- `go-task` を flake `devShell` に追加し、`nix develop -c task ...` で実行できるようにする。

## 設計の意図

- **DDD サービス層メソッド名**: 各境界コンテキストが固有のライフサイクル操作を提供し、集約ルート (`containers`) がそれらを合成する。タスク名はサービス層メソッドの語彙 (launch/shutdown/restart/status) に揃えた。
- **集約ルートを `containers` にした理由**: 当初 `homelab:*` にしていたが、実際に束ねているのは `containers/compose.yaml` 配下のみで、`homelab` というスコープは広すぎるため実態に合わせて変更。
- **`relational_database:launch` の `run: once`**: `containers:launch` と `orchestrator:launch` の双方から依存される。`run: once` がないと dry-run / 通常実行ともに重複起動される。
- **`orchestrator:launch` の `deps`**: Dagster の永続化先である Postgres への依存はコンテキスト境界をまたぐため、Compose の `depends_on` ではなく Task の `deps` で表現する。Compose 側はコンテキスト内 (code-location/webserver/daemon) の順序のみ扱う。

## Test plan

- [x] `nix develop -c task --list` で全 17 タスクが日本語 desc 付きで表示される
- [x] `nix develop -c task --dry containers:launch` で postgres / rustfs / dagster-* の起動が重複なく出力される
- [x] `nix develop -c task --dry containers:shutdown` で全コンテキストの停止コマンドが出力される
- [x] `nix develop -c task --dry containers:status` で `docker compose ps` が出力される
- [ ] ホスト上で `task containers:launch` を実行し、全コンテナが healthy で起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)