### PR TITLE
feat(nix-darwin-server): Tailscale 移植と電源・アップデートのサーバー向け宣言化

### DIFF
--- a/project/nix-darwin-server/flake.nix
+++ b/project/nix-darwin-server/flake.nix
@@ -63,6 +63,10 @@
             ];
           }
 
+          ./module/host.nix
+          ./module/power.nix
+          ./module/software_update.nix
+
           {
             homebrew = {
               enable = true;

--- a/project/nix-darwin-server/module/host.nix
+++ b/project/nix-darwin-server/module/host.nix
@@ -1,0 +1,34 @@
+{ config, pkgs, ... }:
+
+{
+  # make the tailscale command usable to users
+  environment.systemPackages = [ pkgs.tailscale ];
+
+  # enable the tailscale service
+  services.tailscale.enable = true;
+
+  # auto connection
+  launchd.daemons.tailscale-autoconnect = {
+    script = ''
+      AUTH_KEY_FILE="/etc/tailscale/authkey"
+
+      if [ ! -f "$AUTH_KEY_FILE" ]; then
+        echo "Auth key file not found at $AUTH_KEY_FILE"
+        exit 1
+      fi
+
+      sleep 2
+      status="$(${pkgs.tailscale}/bin/tailscale status -json | ${pkgs.jq}/bin/jq -r .BackendState)"
+      if [ "$status" = "Running" ]; then
+        exit 0
+      fi
+
+      ${pkgs.tailscale}/bin/tailscale up --authkey "$(cat $AUTH_KEY_FILE)"
+    '';
+
+    serviceConfig = {
+      RunAtLoad = true;
+      KeepAlive = false;
+    };
+  };
+}

--- a/project/nix-darwin-server/module/power.nix
+++ b/project/nix-darwin-server/module/power.nix
@@ -1,0 +1,12 @@
+{ ... }:
+
+{
+  power.sleep.computer = "never";
+  power.sleep.display = "never";
+  power.sleep.harddisk = "never";
+
+  power.restartAfterPowerFailure = true;
+  power.restartAfterFreeze = true;
+
+  networking.wakeOnLan.enable = true;
+}

--- a/project/nix-darwin-server/module/software_update.nix
+++ b/project/nix-darwin-server/module/software_update.nix
@@ -1,0 +1,16 @@
+{ ... }:
+
+{
+  # CONSTRAINT: メジャー OS 更新の自動適用は無効でなくてはならない。
+  # REASON: 無人再起動が常時稼働のサーバー運用を妨げるため。
+  system.defaults.SoftwareUpdate.AutomaticallyInstallMacOSUpdates = false;
+
+  # CONSTRAINT: セキュリティ更新は CustomSystemPreferences で書かなくてはならない。
+  # REASON: nix-darwin にこれらのキーのネイティブオプションが無いため。
+  system.defaults.CustomSystemPreferences."/Library/Preferences/com.apple.SoftwareUpdate" = {
+    AutomaticCheckEnabled = true;
+    AutomaticDownload = true;
+    CriticalUpdateInstall = true;
+    ConfigDataInstall = true;
+  };
+}


### PR DESCRIPTION
## 概要

Tailscale モジュールを dotfiles から移植し、電源・アップデート設定をサーバー向けに宣言化する 2 モジュールを新設する。

Closes #34 (親 Issue: #32)

## 背景

#37 でビルド基盤 (flake / home-manager / Taskfile) が入り、`project/nix-darwin-server` は評価が通る状態になった。この PR では #32 の中核である「Tailscale 経由でアクセスできる」「常時稼働する」「アップデートがサーバー向けポリシーで管理される」を構成に落とし込む。

## 課題

- Tailscale の導入と自動接続が構成に含まれておらず、外部からの到達経路が無い
- 電源設定が macOS 既定のままで、スリープにより無人運用が中断される
- アップデート設定が未定義で、メジャー OS 更新の無人適用による予期しない再起動と、セキュリティ更新の適用漏れの両リスクがある

## 目標

### 必須項目

- `services.tailscale.enable` と authkey 自動接続 daemon が定義されている
- スリープ全無効・電源喪失/フリーズ後の自動再起動が宣言されている
- メジャー OS 更新は無人適用せず、セキュリティ更新は自動適用するポリシーが宣言されている

### 範囲外

- SSH・画面共有の有効化 (#35 が担う)
- 実マシンへの適用と `pmset -g` / `defaults read` による反映確認 (適用は sudo が必要なユーザー作業)

## 採用手法

電源は nix-darwin ネイティブの `power.*` オプション群で宣言し、dotfiles にあった未配線の imperative スクリプト (`setup_server.sh` の pmset 直叩き) と同等の意図を宣言的に表現した。アップデートは「無人再起動を避けつつセキュリティ更新は止めない」を境界とし、ネイティブオプションが無いキーだけ `CustomSystemPreferences` で `com.apple.SoftwareUpdate` ドメインへ書き込む。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: メジャー更新は手動・セキュリティ更新は自動 (採用) | 予期しない再起動を避けつつ防御は維持できる | メジャー更新時は手動での計画作業が必要 |
| B: `AutomaticallyInstallMacOSUpdates = true` で全自動 | 設定 1 行で完結する | メジャー更新も無人実行され、常時稼働の目標に反する |
| C: アップデートは完全手動 | 実装が最小 | セキュリティ更新の適用が漏れ、受入基準 (宣言的管理) も満たさない |

### 採用理由

サーバーの第一目標は常時稼働であり、無人の長時間ダウンタイムを生む案 B は取れない。一方で外部公開経路 (Tailscale SSH) を持つ以上、セキュリティ更新を止める案 C も取れない。両立できるのは案 A のみである。

## 変更箇所

- `project/nix-darwin-server/module/host.nix`: dotfiles から無変更で移植 (Tailscale サービス + authkey 自動接続 launchd daemon)
- `project/nix-darwin-server/module/power.nix`: スリープ全無効・自動再起動・Wake-on-LAN の宣言
- `project/nix-darwin-server/module/software_update.nix`: メジャー更新の無人適用無効化とセキュリティ更新 (Critical Update / ConfigData) の自動化
- `project/nix-darwin-server/flake.nix`: modules リストへ 3 モジュールを追加

## 妥協と制限

- **CustomSystemPreferences のキーは nix-darwin が意味検証しない**: `AutomaticCheckEnabled` などのキー名は Apple の Software Update 設定プロファイルで使われる語彙であり、タイポしても評価は通ってしまう。適用後の `defaults read /Library/Preferences/com.apple.SoftwareUpdate` での確認手順を #36 で README に残す
- **authkey の配置は手動**: `/etc/tailscale/authkey` が無い場合、自動接続 daemon は exit 1 して Tailscale 未接続のままになる (dotfiles と同じ挙動)

## 検証方法

- `nix build .#darwinConfigurations.homelab-server.system --dry-run` — 3 モジュール込みで評価エラーなし
- `nix flake check` — 通過
- `nix fmt` — 差分なし

## 確認事項

- ⚠️ アップデートポリシーの境界 (メジャー更新 = 手動、セキュリティ更新 = 自動) がサーバー運用方針として妥当か

## 参考文献

- [親 Issue #32: nix-darwin サーバー構成の新設](https://github.com/shunsock/homelab/issues/32)
- [サブイシュー #34: 電源・アップデート宣言化](https://github.com/shunsock/homelab/issues/34)
- [nix-darwin power options (modules/power)](https://github.com/nix-darwin/nix-darwin/tree/master/modules/power)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
