### PR TITLE
feat(nix-darwin-server): SSH と画面共有を宣言化しリモートアクセスを許可する

### DIFF
--- a/project/nix-darwin-server/README.md
+++ b/project/nix-darwin-server/README.md
@@ -22,6 +22,21 @@ macOS (Apple Silicon) を自宅サーバーとして常時稼働させるため�
 
 `task apply` は `darwin-rebuild switch` を含むため sudo を要求する。CI や Claude などの非対話環境からは実行できないので、コンソールまたは SSH セッションから手動で実行すること。
 
+## リモートアクセス
+
+`module/remote_access.nix` が SSH (Remote Login) と画面共有 (Screen Sharing) を有効化する。SSH は `services.openssh.enable`、画面共有は launchctl を用いた activationScript で宣言している。
+
+### 画面共有の初回セットアップ (手動、コンソール作業)
+
+画面共有の実接続には TCC (Transparency, Consent, and Control) の許可が必要で、これは CLI や Nix からは付与できない。初回のみ、物理コンソール (ディスプレイとキーボードを直接接続) で次を行うこと。
+
+1. システム設定 > プライバシーとセキュリティ > 画面収録 を開き、必要な権限を許可する
+2. リモートから macOS 標準の「画面共有」アプリで Tailscale IP へ接続し、接続できることを確認する
+
+### コンソールアクセスの前提
+
+コンソールアクセスは物理的なディスプレイ・キーボード接続そのものであり、Nix 宣言の対象外である。macOS は初期状態でローカルコンソールログインを許可しているため追加設定は不要だが、初回セットアップ (上記 TCC 許可と `task init` / `task apply`) にはコンソール作業が必要になる。
+
 ## 構成
 
 - `flake.nix` — `darwinConfigurations."homelab-server"` の定義。Homebrew casks は Google Chrome のみを導入する

--- a/project/nix-darwin-server/flake.nix
+++ b/project/nix-darwin-server/flake.nix
@@ -65,6 +65,7 @@
 
           ./module/host.nix
           ./module/power.nix
+          ./module/remote_access.nix
           ./module/software_update.nix
 
           {

--- a/project/nix-darwin-server/module/remote_access.nix
+++ b/project/nix-darwin-server/module/remote_access.nix
@@ -1,0 +1,15 @@
+{ ... }:
+
+{
+  # CONSTRAINT: SSH は services.openssh で有効化しなくてはならない。
+  # REASON: systemsetup -setremotelogin は Full Disk Access を要求するため。
+  services.openssh.enable = true;
+
+  # HACK: 画面共有には nix-darwin のネイティブオプションが無い。
+  # openssh モジュールと同じ launchctl パターンを activationScript 化する。
+  system.activationScripts.screenSharing.text = ''
+    echo "configuring screen sharing..." >&2
+    launchctl enable system/com.apple.screensharing
+    launchctl bootstrap system /System/Library/LaunchDaemons/com.apple.screensharing.plist 2>/dev/null || true
+  '';
+}


### PR DESCRIPTION
## 概要

SSH (Remote Login) と画面共有 (Screen Sharing) を宣言的に有効化する `module/remote_access.nix` を追加し、リモートデスクトップ初回接続に必要な手動手順を README に明文化する。

Closes #35 (親 Issue: #32)

## 背景

#38 で Tailscale の導線と常時稼働の電源設定が入ったが、到達した先でログインする手段 (SSH) と画面を操作する手段 (画面共有) がまだ構成に無い。#32 の受入基準「Tailscale 経由で SSH ログインできる」「リモートデスクトップとコンソールアクセスで接続できる」を満たすのがこの PR である。

## 課題

- macOS の Remote Login / Screen Sharing は既定で無効であり、有効化を宣言的に管理する手段が構成に無い
- 画面共有の実接続には TCC の許可という Nix では表現できない手動手順があり、ドキュメント化しないと適用後に「接続できない」で詰まる

## 目標

### 必須項目

- `services.openssh.enable = true` が定義されている
- 画面共有 (`com.apple.screensharing`) を有効化する `system.activationScripts` が定義されている
- README に TCC 許可手順とコンソールアクセスの前提が記載されている

### 範囲外

- 実マシンでの SSH / 画面共有の接続確認 (適用は sudo・物理作業が必要なユーザー作業)
- 統合検証と README の仕上げ (#36 が担う)

## 採用手法

SSH は nix-darwin ネイティブの `services.openssh` を使う。このモジュールは `systemsetup -setremotelogin` (Full Disk Access を要求し無人適用で失敗しうる) を意図的に避け、`launchctl enable/bootstrap system/com.openssh.sshd` で有効化する実装になっている。画面共有にはネイティブオプションが存在しないため、同じ launchctl パターンを `system.activationScripts.screenSharing` として自前で宣言した。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: openssh ネイティブ + 画面共有は activationScript (採用) | 無人適用で失敗せず、`task apply` に一元化できる | 画面共有部分は自前実装で、nix-darwin の更新に追従する保守責任を負う |
| B: `systemsetup -setremotelogin on` を activationScript で実行 | dotfiles の setup_server.sh と同じ手法 | Full Disk Access が必要で、TCC 未許可の環境では適用が失敗する |
| C: 画面共有は手動有効化 (宣言化しない) | 実装が最小 | `task apply` 一発で完結せず、受入基準の宣言的管理から外れる |

### 採用理由

「適用が環境の TCC 状態に左右されない」ことを最優先した。案 B は初回の無人適用で失敗し、案 C はサーバー再構築時に手作業が復活する。案 A だけが再現可能性を保てる。TCC 許可 (画面収録) はどの案でも回避できない macOS の制約なので、コードではなく README の初回セットアップ手順として残した。

## 変更箇所

- `project/nix-darwin-server/module/remote_access.nix`: SSH と画面共有の宣言的有効化
- `project/nix-darwin-server/flake.nix`: modules リストへ remote_access.nix を追加
- `project/nix-darwin-server/README.md`: TCC 許可手順・コンソールアクセスの前提を追記

## 妥協と制限

- **TCC 許可は手動**: 画面共有の実接続に必要な画面収録権限は SIP の制約で CLI / Nix から付与できない。初回のみ物理コンソールでの GUI 操作が必要
- **launchctl bootstrap のエラーは握りつぶす**: 既にロード済みの場合に bootstrap が非ゼロ終了するため `|| true` としている。enable との組み合わせで冪等性を確保する設計だが、初回失敗の検知は弱くなる

## 検証方法

- `nix build .#darwinConfigurations.homelab-server.system --dry-run` — 評価エラーなし
- `nix flake check` — 通過
- `nix fmt` — 差分なし

## 確認事項

- ⚠️ 画面共有を macOS 標準の Screen Sharing (VNC) で運用する前提で良いか。Apple Remote Desktop (ARD) 管理を使う場合は `kickstart` ベースの別実装になる

## 参考文献

- [親 Issue #32: nix-darwin サーバー構成の新設](https://github.com/shunsock/homelab/issues/32)
- [サブイシュー #35: リモートアクセスの宣言化](https://github.com/shunsock/homelab/issues/35)
- [nix-darwin services.openssh (modules/services/openssh.nix)](https://github.com/nix-darwin/nix-darwin/blob/master/modules/services/openssh.nix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
