### PR TITLE
docs(nix-darwin-server): 統合検証の完了と運用ドキュメントの仕上げ

### DIFF
--- a/project/nix-darwin-server/README.md
+++ b/project/nix-darwin-server/README.md
@@ -37,6 +37,43 @@ macOS (Apple Silicon) を自宅サーバーとして常時稼働させるため�
 
 コンソールアクセスは物理的なディスプレイ・キーボード接続そのものであり、Nix 宣言の対象外である。macOS は初期状態でローカルコンソールログインを許可しているため追加設定は不要だが、初回セットアップ (上記 TCC 許可と `task init` / `task apply`) にはコンソール作業が必要になる。
 
+## 適用後の確認 (手動)
+
+`task apply` の適用後、各設定が反映されたことを次のコマンドで確認する。
+
+| 確認対象 | コマンド | 期待値 |
+|---|---|---|
+| 電源設定 | `pmset -g` | `sleep 0` / `displaysleep 0` / `disksleep 0` / `autorestart 1` |
+| アップデート設定 | `defaults read /Library/Preferences/com.apple.SoftwareUpdate` | `AutomaticCheckEnabled = 1` など。`AutomaticallyInstallMacOSUpdates = 0` |
+| SSH | `systemsetup -getremotelogin` と別マシンからの `ssh <user>@<tailscale-ip>` | `Remote Login: On`、ログイン成功 |
+| 画面共有 | `launchctl print system/com.apple.screensharing` と「画面共有」アプリからの接続 | ロード済み、接続成功 (初回は TCC 許可が必要) |
+| Tailscale | `tailscale status` | Running (authkey 配置済みの場合) |
+| ブラウザ | `brew list --cask` | `google-chrome` があり `arc` が無い |
+
+## dotfiles の setup_server.sh との対応
+
+dotfiles には pmset を直接叩く未配線のスクリプト (`script/entry_point/setup_server.sh`) があった。本プロジェクトではその意図を次の宣言的設定へ置き換えている。
+
+| setup_server.sh の操作 | 本プロジェクトでの宣言 |
+|---|---|
+| `pmset sleep 0` / `displaysleep 0` / `disksleep 0` | `module/power.nix` の `power.sleep.* = "never"` |
+| `pmset autorestart 1` | `module/power.nix` の `power.restartAfterPowerFailure = true` |
+| `pmset womp 1` (Wake on LAN) | `module/power.nix` の `networking.wakeOnLan.enable = true` |
+| `systemsetup -setremotelogin on` | `module/remote_access.nix` の `services.openssh.enable = true` |
+
+## 受入基準との対応
+
+親 Issue の受入基準と、それを満たす実装の対応は次のとおり。
+
+| 受入基準 | 実装 |
+|---|---|
+| flake が build / validate を通過する | `task build` / `task validate` (CI 相当の検証はローカルで実行) |
+| Tailscale 経由で SSH ログインできる | `module/host.nix` + `module/remote_access.nix` |
+| リモートデスクトップとコンソールで接続できる | `module/remote_access.nix` + 初回の TCC 許可 (上記手順) |
+| 自動スリープせず常時稼働する | `module/power.nix` |
+| アップデートがサーバー向けポリシーで宣言管理されている | `module/software_update.nix` |
+| Arc が無く Google Chrome がある | `flake.nix` の `homebrew.casks` |
+
 ## 構成
 
 - `flake.nix` — `darwinConfigurations."homelab-server"` の定義。Homebrew casks は Google Chrome のみを導入する


### PR DESCRIPTION
## 概要

`project/nix-darwin-server` の統合検証 (build / validate / format の全通過) を完了し、運用に必要な確認手順と対応表を README に整理する。

Closes #36 (親 Issue: #32)

## 背景

#37 / #38 / #39 で flake のビルド基盤・Tailscale・電源・アップデート・リモートアクセスが揃った。#32 のサブイシューとしては最後の仕上げであり、構成全体が受入基準を満たすことの確認と、適用後の運用手順のドキュメント化を行う。

## 課題

- 各 PR は評価 (dry-run) ベースの検証だったため、system derivation まで作る実ビルドでの通過を確認していなかった
- 適用後に何をどう確認すればよいか (pmset / defaults / ssh / 画面共有 / brew) が README に無く、受入基準との対応も追えなかった

## 目標

### 必須項目

- `task build` (nix-darwin build) / `task validate` (nix flake check) / `task format` がすべて通過する
- README に適用後の手動確認手順・受入基準対応表・setup_server.sh との対応表がある

### 範囲外

- 実マシンへの `task apply` と実機での接続確認 (sudo・物理作業が必要なユーザー作業)

## 採用手法

検証はプロジェクトの Taskfile が呼ぶスクリプトをそのまま実行し、CI や手元の環境差に依存しない「利用者と同じ経路」で確認した。ドキュメントは散文ではなく対応表を中心に構成し、受入基準 → 実装 → 確認コマンドを 1 対 1 で追えるようにした。

## 変更箇所

- `project/nix-darwin-server/README.md`: 適用後の手動確認手順、dotfiles の `setup_server.sh` (imperative な pmset) と宣言的設定の対応表、受入基準と実装の対応表を追記

## 妥協と制限

- **実機適用は未実施**: `task apply` は sudo を要するため、この PR では build までの検証に留まる。適用と接続確認は README の手順に沿ってユーザーが実施する

## 検証方法

- `bash script/entry_point/nix/build.sh` — system derivation (`darwin-system-26.05.c3e90c8`) のビルドまで成功
- `bash script/entry_point/nix/check.sh` — `nix flake check` 通過
- `nix fmt` — 差分なし

## 確認事項

- ⚠️ 実機適用後、README「適用後の確認 (手動)」の表に沿った動作確認をお願いしたい

## 参考文献

- [親 Issue #32: nix-darwin サーバー構成の新設](https://github.com/shunsock/homelab/issues/32)
- [サブイシュー #36: 統合検証とドキュメント仕上げ](https://github.com/shunsock/homelab/issues/36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
