### PR TITLE
fix(nix-darwin-server): sshd に ClientAlive keepalive を設定し broken pipe を防ぐ

### DIFF
--- a/project/nix-darwin-server/module/remote_access.nix
+++ b/project/nix-darwin-server/module/remote_access.nix
@@ -5,6 +5,13 @@
   # REASON: systemsetup -setremotelogin は Full Disk Access を要求するため。
   services.openssh.enable = true;
 
+  # CONSTRAINT: sshd は ClientAlive による keepalive を送信しなくてはならない。
+  # REASON: 無通信時に経路上の NAT マッピングが失効し broken pipe になるため。
+  services.openssh.extraConfig = ''
+    ClientAliveInterval 30
+    ClientAliveCountMax 4
+  '';
+
   # HACK: 画面共有には nix-darwin のネイティブオプションが無い。
   # openssh モジュールと同じ launchctl パターンを activationScript 化する。
   system.activationScripts.screenSharing.text = ''


### PR DESCRIPTION
## 概要

SSH セッションが短時間のアイドルで broken pipe になる問題に対し、sshd に ClientAlive keepalive 設定を追加する。

## 背景

このサーバへの SSH 接続 (主に Tailscale 経由) で、少し放置しただけのセッションが broken pipe で切断される事象が報告された。実機の設定を調査したところ、sshd は `services.openssh.enable = true` のみで運用しており、有効な keepalive 設定が存在しなかった。

## 課題

- sshd の `ClientAliveInterval` が macOS デフォルトの `0` のため、sshd はアイドル中のクライアントへ keepalive を一切送信しない
- `TCPKeepAlive yes` は有効だが、macOS の TCP keepalive 初回プローブは `net.inet.tcp.keepidle = 7200000` (2 時間後) であり、数十秒〜数分で失効する経路上の NAT アイドルタイムアウトに間に合わない
- クライアント側 (`~/.ssh/config`) にも `ServerAliveInterval` が無く、双方向とも完全な無通信になった時点で NAT マッピングが破棄され、次の入力で broken pipe が発生する

## 目標

### 必須項目

- アイドル状態の SSH セッションでも定期的に keepalive が流れ、NAT マッピングが維持されること
- 設定が nix-darwin の宣言的管理下に置かれ、再現可能であること

### 範囲外

- 接続元マシンのクライアント設定 (`ServerAliveInterval`)。dotfiles 側の管轄であり、本 PR ではサーバ側のみ対処する
- Tailscale 自体の経路・NAT 挙動の調整

## 採用手法

`services.openssh.extraConfig` で sshd に `ClientAliveInterval 30` / `ClientAliveCountMax 4` を宣言する。nix-darwin はこれを `/etc/ssh/sshd_config.d/100-nix-darwin.conf` (現在は何も書き込まれていないファイル) に書き出すため、macOS 標準の設定ファイルを直接編集せずに済む。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: sshd の ClientAlive (採用) | 暗号化チャネル内で送られ NAT/FW を確実に通過する。全クライアントに一括で効く。サーバ 1 箇所の宣言で完結 | 切断検知はサーバ側視点のみ |
| B: クライアントの ServerAliveInterval | クライアント側の切断検知も改善する | 接続元マシン全台の設定が必要で、このリポジトリの管轄外 |
| C: TCP keepalive のカーネルパラメータ短縮 | SSH 以外の接続にも効く | システム全体への影響が大きく、SSH の問題に対して過剰 |

### 採用理由

このリポジトリはサーバの宣言的構成を管理しており、サーバ側 1 箇所の変更で全クライアントの broken pipe を解消できる案 A が最も影響範囲と管轄が一致する。案 B は補完として有効なので dotfiles 側で別途対応できる。

## 変更箇所

- `project/nix-darwin-server/module/remote_access.nix`: `services.openssh.extraConfig` に `ClientAliveInterval 30` / `ClientAliveCountMax 4` を追加

## 妥協と制限

- **切断判定の導入**: keepalive 応答が 120 秒 (30 秒 × 4 回) 途絶えたセッションはサーバ側から切断されるようになる。従来の「無期限に放置されたゾンビセッションが残る」挙動より望ましいと判断した
- **微小なアイドルトラフィック**: 30 秒ごとに数十バイトのパケットが流れるが、実用上無視できる

## 検証方法

- `nix run nixpkgs#nixfmt-rfc-style -- --check` でフォーマット検証済み
- `nix flake check` で `darwinConfigurations` の評価が通ることを確認済み
- 適用後は `sshd -T | grep -i clientalive` 相当の確認、およびアイドルセッションが従来の切断時間を超えて維持されることを実測で確認する

## 確認事項

- ⚠️ interval 30 秒 / countmax 4 回 (切断判定 120 秒) の値が運用感覚に合うか。より長く粘らせたい場合は countmax を増やすのが安全

## 参考文献

- [sshd_config(5) — ClientAliveInterval / ClientAliveCountMax](https://man.openbsd.org/sshd_config#ClientAliveInterval)
- [nix-darwin services.openssh options](https://nix-darwin.github.io/nix-darwin/manual/index.html)
